### PR TITLE
fixes: Template can't be imported into Zabbix 5.4.3

### DIFF
--- a/zabbix-5.4.3/template.xml
+++ b/zabbix-5.4.3/template.xml
@@ -1,0 +1,811 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>5.2</version>
+    <date>2020-12-03T22:30:30Z</date>
+    <groups>
+        <group>
+            <name>Templates/Network devices</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <template>Template SNMP QNAP</template>
+            <name>Template SNMP QNAP</name>
+            <templates>
+                <template>
+                    <name>ICMP Ping</name>
+                </template>
+            </templates>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <applications>
+                <application>
+                    <name>Disks</name>
+                </application>
+                <application>
+                    <name>iSCSI &amp; LUN</name>
+                </application>
+                <application>
+                    <name>Network</name>
+                </application>
+                <application>
+                    <name>Pools</name>
+                </application>
+                <application>
+                    <name>RAID</name>
+                </application>
+                <application>
+                    <name>System Hardware</name>
+                </application>
+                <application>
+                    <name>System Information</name>
+                </application>
+                <application>
+                    <name>Volumes</name>
+                </application>
+            </applications>
+            <items>
+                <item>
+                    <name>CPU Temperature</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.4.2.0</snmp_oid>
+                    <key>cpu.temp</key>
+                    <delay>30m</delay>
+                    <history>7d</history>
+                    <trends>7d</trends>
+                    <applications>
+                        <application>
+                            <name>System Hardware</name>
+                        </application>
+                    </applications>
+                    <triggers>
+                        <trigger>
+                            <expression>{min(15m)}&gt;={$CPU_TEMPERATURE_ALARM}</expression>
+                            <name>High CPU temperature (&gt;{$CPU_TEMPERATURE_ALARM} for 15m)</name>
+                            <opdata>Current temperature: {ITEM.VALUE}</opdata>
+                            <priority>WARNING</priority>
+                            <description>The CPU temperature is exceeding the threshold.</description>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <name>Disk IOPS</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.24681.1.4.1.11.5.6.2.1.3.1</snmp_oid>
+                    <key>disk.iops</key>
+                    <delay>15m</delay>
+                    <history>7d</history>
+                    <trends>7d</trends>
+                    <applications>
+                        <application>
+                            <name>Disks</name>
+                        </application>
+                    </applications>
+                </item>
+                <item>
+                    <name>Disk latency</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.24681.1.4.1.11.5.6.2.1.4.1</snmp_oid>
+                    <key>disk.latency</key>
+                    <delay>15m</delay>
+                    <history>7d</history>
+                    <trends>7d</trends>
+                    <applications>
+                        <application>
+                            <name>Disks</name>
+                        </application>
+                    </applications>
+                    <triggers>
+                        <trigger>
+                            <expression>{min(15m)}&gt;={$DISK_LATENCY_ALARM}</expression>
+                            <name>Disk latency is high (&gt;{$DISK_LATENCY_ALARM} for 15m)</name>
+                            <opdata>Current latency: {ITEM.VALUE}</opdata>
+                            <priority>WARNING</priority>
+                            <description>The latency of the disks are higher than the threshhold for 15 minutes.</description>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <name>System Temperature</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.1.2.1.7.1</snmp_oid>
+                    <key>system.temp</key>
+                    <delay>30m</delay>
+                    <history>7d</history>
+                    <trends>7d</trends>
+                    <applications>
+                        <application>
+                            <name>System Hardware</name>
+                        </application>
+                    </applications>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Disk Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#HDDINDEX},1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.1]</snmp_oid>
+                    <key>disk.discovery</key>
+                    <delay>15m</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>HDD {#HDDINDEX}: Capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.9.{#HDDINDEX}</snmp_oid>
+                            <key>hdd.capacity[{#HDDINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>HDD {#HDDINDEX}: Model</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.8.{#HDDINDEX}</snmp_oid>
+                            <key>hdd.model[{#HDDINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>Disks</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>HDD {#HDDINDEX}: Hot Spare</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.7.{#HDDINDEX}</snmp_oid>
+                            <key>hdd.spare[{#HDDINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>QNAP Hot Spare</name>
+                            </valuemap>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>HDD {#HDDINDEX}: State</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.3.11.1.4.{#HDDINDEX}</snmp_oid>
+                            <key>hdd.state[{#HDDINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>Disks</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}=1</expression>
+                                    <name>HDD {#HDDINDEX} (hotspare) is in operation</name>
+                                    <priority>WARNING</priority>
+                                    <description>Harddisk was previously a hot spare but is now in operation.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>HDD {#HDDINDEX}: SMART Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.5.{#HDDINDEX}</snmp_oid>
+                            <key>hdd.status[{#HDDINDEX}]</key>
+                            <delay>30m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>Disks</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>QNAP S.M.A.R.T State</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;&gt;0</expression>
+                                    <name>Faulty SMART state of HDD {#HDDINDEX}</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>HIGH</priority>
+                                    <description>S.M.A.R.T has alerted a faulty state of the disk.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>HDD {#HDDINDEX}: Temperature</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.5.2.1.6.{#HDDINDEX}</snmp_oid>
+                            <key>hdd.temp[{#HDDINDEX}]</key>
+                            <delay>30m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>Disks</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{min(15m)}&gt;{$HDD_TEMPERATURE_ALARM}</expression>
+                                    <name>Temperature of HDD {#HDDINDEX} is excessive for 15m</name>
+                                    <opdata>Current temperature: {ITEM.VALUE}</opdata>
+                                    <priority>WARNING</priority>
+                                    <description>Harddisk temperature is higher than the threshold for 15 minutes.</description>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>Temperature of HDD {#HDDINDEX} is high for 5m</name>
+                                            <expression>{Template SNMP QNAP:hdd.temp[{#HDDINDEX}].min(5m)}&gt;{$HDD_TEMPERATURE_ALARM}</expression>
+                                        </dependency>
+                                    </dependencies>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <expression>{min(5m)}&gt;{$HDD_TEMPERATURE_ALARM}</expression>
+                                    <name>Temperature of HDD {#HDDINDEX} is high for 5m</name>
+                                    <opdata>Current temperature: {ITEM.VALUE}</opdata>
+                                    <priority>INFO</priority>
+                                    <description>Harddisk temperature is higher than the threshold for 5 minutes.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>FAN Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#FANINDEX},1.3.6.1.4.1.24681.1.4.1.1.1.1.2.2.1.1]</snmp_oid>
+                    <key>fan.discovery</key>
+                    <delay>15m</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>FAN {#FANINDEX}: Name</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.3.15.1.2.{#FANINDEX}</snmp_oid>
+                            <key>fan.name[{#FANINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>System Hardware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>FAN {#FANINDEX}: Speed</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.2.2.1.5.{#FANINDEX}</snmp_oid>
+                            <key>fan.speed[{#FANINDEX}]</key>
+                            <delay>30m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>System Hardware</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>FAN {#FANINDEX}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.1.2.2.1.4.{#FANINDEX}</snmp_oid>
+                            <key>fan.status[{#FANINDEX}]</key>
+                            <delay>30m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>System Hardware</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>Alarm state</name>
+                            </valuemap>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>LUN Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#LUNINDEX},1.3.6.1.4.1.24681.1.4.1.1.2.1.11.2.1.1]</snmp_oid>
+                    <key>lun.discovery</key>
+                    <delay>15m</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>LUN {#LUNINDEX}: Name</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.2.1.11.2.1.3.{#LUNINDEX}</snmp_oid>
+                            <key>lun.name[{#LUNINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>iSCSI &amp; LUN</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>LUN {#LUNINDEX}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.2.1.11.2.1.5.{#LUNINDEX}</snmp_oid>
+                            <key>lun.status[{#LUNINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>iSCSI &amp; LUN</name>
+                                </application>
+                            </applications>
+                            <valuemap>
+                                <name>QNAP LUN Status</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;0</expression>
+                                    <name>State of LUN {#LUNINDEX} is disconnected</name>
+                                    <priority>WARNING</priority>
+                                    <description>The target of LUN is disconnected.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Network interfaces discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#IFINDEX},1.3.6.1.4.1.24681.1.2.9.1.1,{#IFNAME},1.3.6.1.4.1.24681.1.2.9.1.2]</snmp_oid>
+                    <key>network.discovery</key>
+                    <delay>15m</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#IFNAME}</macro>
+                                <value>{$NET_IF_MATCHES}</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Interface {#IFNAME}: Bits received</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.2.9.1.3.{#IFINDEX}</snmp_oid>
+                            <key>net.if.received[{#IFINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>bps</units>
+                            <applications>
+                                <application>
+                                    <name>Network</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Interface {#IFNAME}: Bits sent</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.2.9.1.4.{#IFINDEX}</snmp_oid>
+                            <key>net.if.sent[{#IFINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>bps</units>
+                            <applications>
+                                <application>
+                                    <name>Network</name>
+                                </application>
+                            </applications>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Pool Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#POOLINDEX},1.3.6.1.4.1.24681.1.4.1.1.1.2.2.2.1.1]</snmp_oid>
+                    <key>pool.discovery</key>
+                    <delay>15m</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Pool {#POOLINDEX}: Capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.2.2.1.3.{#POOLINDEX}</snmp_oid>
+                            <key>pool.capacity[{#POOLINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>Pools</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Pool {#POOLINDEX}: Free size in %</name>
+                            <type>CALCULATED</type>
+                            <key>pool.freepercentage[{#POOLINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <params>last(&quot;pool.freeSize[{#POOLINDEX}]&quot;)/last(&quot;pool.capacity[{#POOLINDEX}]&quot;)*100</params>
+                            <applications>
+                                <application>
+                                    <name>Pools</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;{$POOL_SIZE_ALARM}</expression>
+                                    <name>Reaching threshold for pool {#POOLINDEX} (&lt;{$POOL_SIZE_ALARM}%)</name>
+                                    <opdata>Current %: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>WARNING</priority>
+                                    <description>The free size of the pool is reaching the threshold.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Pool {#POOLINDEX}: Free size</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.2.2.1.4.{#POOLINDEX}</snmp_oid>
+                            <key>pool.freeSize[{#POOLINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>Pools</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Pool {#POOLINDEX}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.2.2.1.5.{#POOLINDEX}</snmp_oid>
+                            <key>pool.status[{#POOLINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>Pools</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;&gt;0</expression>
+                                    <name>Faulty state of Pool {#POOLINDEX}</name>
+                                    <priority>HIGH</priority>
+                                    <description>A faulty state has been reported by the pool.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>RAID Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#RAIDINDEX},1.3.6.1.4.1.24681.1.4.1.1.1.2.1.2.1.1]</snmp_oid>
+                    <key>raid.discovery</key>
+                    <delay>15m</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>RAID {#RAIDINDEX}: Capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.1.2.1.3.{#RAIDINDEX}</snmp_oid>
+                            <key>raid.capacity[{#RAIDINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>RAID</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>RAID {#RAIDINDEX}: Free size</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.1.2.1.4.{#RAIDINDEX}</snmp_oid>
+                            <key>raid.freeSize[{#RAIDINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>RAID</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>RAID {#RAIDINDEX}: Level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.1.2.1.7.{#RAIDINDEX}</snmp_oid>
+                            <key>raid.level[{#RAIDINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <applications>
+                                <application>
+                                    <name>RAID</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>RAID {#RAIDINDEX}: State</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.1.2.1.5.{#RAIDINDEX}</snmp_oid>
+                            <key>raid.state[{#RAIDINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>RAID</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{iregexp(&quot;^Ready|Synchronizing&quot;)}=0</expression>
+                                    <name>Faulty state of RAID {#RAIDINDEX}</name>
+                                    <opdata>Current state: {ITEM.VALUE}</opdata>
+                                    <priority>HIGH</priority>
+                                    <description>RAID has reported a faulty state.</description>
+                                    <manual_close>YES</manual_close>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>if(value == 'Single') { return 0; }
+return value;</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <name>Volume Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#VOLUMEINDEX},1.3.6.1.4.1.24681.1.4.1.1.1.2.3.2.1.1]</snmp_oid>
+                    <key>volume.discovery</key>
+                    <delay>15m</delay>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Volume {#VOLUMEINDEX}: Capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.3.2.1.3.{#VOLUMEINDEX}</snmp_oid>
+                            <key>volume.capacity[{#VOLUMEINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>Volumes</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Volume {#VOLUMEINDEX}: Free size in %</name>
+                            <type>CALCULATED</type>
+                            <key>volume.freePercentage[{#VOLUMEINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <params>last(volume.freeSize[{#VOLUMEINDEX}])/last(volume.capacity[{#VOLUMEINDEX}])*100</params>
+                            <applications>
+                                <application>
+                                    <name>Volumes</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{last()}&lt;{$VOLUME_SIZE_ALARM}</expression>
+                                    <name>Reaching threshold for volume {#VOLUMEINDEX} (&lt;{$VOLUME_SIZE_ALARM}%)</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>WARNING</priority>
+                                    <description>The free size of the volume is reaching the threshold.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Volume {#VOLUMEINDEX}: Free size</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.3.2.1.4.{#VOLUMEINDEX}</snmp_oid>
+                            <key>volume.freeSize[{#VOLUMEINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>7d</trends>
+                            <units>B</units>
+                            <applications>
+                                <application>
+                                    <name>Volumes</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Volume {#VOLUMEINDEX}: Name</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.3.2.1.8.{#VOLUMEINDEX}</snmp_oid>
+                            <key>volume.name[{#VOLUMEINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>Volumes</name>
+                                </application>
+                            </applications>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Volume {#VOLUMEINDEX}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.24681.1.4.1.1.1.2.3.2.1.5.{#VOLUMEINDEX}</snmp_oid>
+                            <key>volume.status[{#VOLUMEINDEX}]</key>
+                            <delay>15m</delay>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <value_type>TEXT</value_type>
+                            <applications>
+                                <application>
+                                    <name>Volumes</name>
+                                </application>
+                            </applications>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <expression>{iregexp(&quot;^Ready&quot;)}=0</expression>
+                                    <name>Faulty state of volume {#VOLUMEINDEX}</name>
+                                    <opdata>Current state: {ITEM.VALUE}</opdata>
+                                    <priority>DISASTER</priority>
+                                    <description>Volume is in a faulty state. Check as soon as possible.</description>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$CPU_TEMPERATURE_ALARM}</macro>
+                    <value>65</value>
+                    <description>Amount in centigrade when an alarm shall be raised</description>
+                </macro>
+                <macro>
+                    <macro>{$DISK_LATENCY_ALARM}</macro>
+                    <value>30</value>
+                    <description>Amount in ms when an alarm shall be raised</description>
+                </macro>
+                <macro>
+                    <macro>{$HDD_TEMPERATURE_ALARM}</macro>
+                    <value>50</value>
+                    <description>Amount in centigrade when an alarm shall be raised</description>
+                </macro>
+                <macro>
+                    <macro>{$NET_IF_MATCHES}</macro>
+                    <value>^.*$</value>
+                    <description>Regex matches for network interfaces discovery. Matches to the inteface desc which is (eth0, eth1, etc)</description>
+                </macro>
+                <macro>
+                    <macro>{$POOL_SIZE_ALARM}</macro>
+                    <value>15</value>
+                    <description>Amount in % when an alarm shall be raised</description>
+                </macro>
+            </macros>
+        </template>
+    </templates>
+    <value_maps>
+        <value_map>
+            <name>Alarm state</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>Ok</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Alarm</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>QNAP Hot Spare</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>No</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Yes</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>QNAP LUN Status</name>
+            <mappings>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>Disconnected</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Connected</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>QNAP S.M.A.R.T State</name>
+            <mappings>
+                <mapping>
+                    <value>-1</value>
+                    <newvalue>Error</newvalue>
+                </mapping>
+                <mapping>
+                    <value>0</value>
+                    <newvalue>Good</newvalue>
+                </mapping>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Warning</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>Abnormal</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+    </value_maps>
+</zabbix_export>


### PR DESCRIPTION
Hi, the Template can't be imported into Zabbix 5.4.3. :-/ It seems that the “Template Module ICMP Ping (5.x)” (which the Template is linking to) was renamed into “ICMP Ping” there. This patch fixes this and works fine for me. 


```
s3h10r@milliways zabbix-qnap-template % diff zabbix-5.x/template.xml zabbix-5.4.3/template.xml
16c16
<                     <name>Template Module ICMP Ping</name>
---
>                     <name>ICMP Ping</name>
```

Greetings, Sven