### PR TITLE
[backport] backported changes from a818e37

### DIFF
--- a/zabbix-4.x/Firmware 4.5.1 or lower/template.xml
+++ b/zabbix-4.x/Firmware 4.5.1 or lower/template.xml
@@ -11,11 +11,6 @@
         <template>
             <template>Template SNMP QNAP</template>
             <name>Template SNMP QNAP</name>
-            <templates>
-                <template>
-                    <name>Template Module Generic SNMPv2</name>
-                </template>
-            </templates>
             <groups>
                 <group>
                     <name>Templates/Network devices</name>

--- a/zabbix-5.4.3/Firmware 4.5.1 or lower/template.xml
+++ b/zabbix-5.4.3/Firmware 4.5.1 or lower/template.xml
@@ -11,11 +11,6 @@
         <template>
             <template>Template SNMP QNAP</template>
             <name>Template SNMP QNAP</name>
-            <templates>
-                <template>
-                    <name>ICMP Ping</name>
-                </template>
-            </templates>
             <groups>
                 <group>
                     <name>Templates/Network devices</name>

--- a/zabbix-5.x/Firmware 4.5.1 or lower/template.xml
+++ b/zabbix-5.x/Firmware 4.5.1 or lower/template.xml
@@ -11,11 +11,6 @@
         <template>
             <template>Template SNMP QNAP</template>
             <name>Template SNMP QNAP</name>
-            <templates>
-                <template>
-                    <name>Template Module ICMP Ping</name>
-                </template>
-            </templates>
             <groups>
                 <group>
                     <name>Templates/Network devices</name>

--- a/zabbix-5.x/Firmware 4.5.2 or higher/template-backported.yaml
+++ b/zabbix-5.x/Firmware 4.5.2 or higher/template-backported.yaml
@@ -10,9 +10,6 @@ zabbix_export:
       uuid: 8e02b71d47ee4b1e9631a7460da058a3
       template: 'Template SNMP QNAP'
       name: 'Template SNMP QNAP'
-      templates:
-        -
-          name: 'ICMP Ping'
       groups:
         -
           name: 'Templates/Network devices'


### PR DESCRIPTION
Removing default ICMP template because there is already a trigger for no data collection.

Resolves #10 